### PR TITLE
drivers/display/ssd1306.py

### DIFF
--- a/drivers/display/ssd1306.py
+++ b/drivers/display/ssd1306.py
@@ -74,6 +74,10 @@ class SSD1306(framebuf.FrameBuffer):
 
     def invert(self, invert):
         self.write_cmd(SET_NORM_INV | (invert & 1))
+        
+    def upside_down(self):
+        self.write_cmd(SET_SEG_REMAP)
+        self.write_cmd(SET_COM_OUT_DIR)
 
     def show(self):
         x0 = 0


### PR DESCRIPTION
The added `upside_down` static method causes the contents to be rendered with a 180° rotation.
If a display is to be run upside down, this method must be called prior to instantiating a `Writer` for this display.
This particular OLED command sequence was originally discussed [here](https://digistump.com/board/index.php?topic=1669.0).

A similar static method [only works for the `Cwriter` class](https://github.com/peterhinch/micropython-font-to-py/blob/master/writer/WRITER.md#221-static-method).